### PR TITLE
Add support in nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ JavaScript, PHP, Python, Perl, Ruby, Go, Lua**, etc.
 * Support user input in output window when the program reads from standard input
 * Make the command configable, user can override the settings
 
+## Supported vim version
+
+- vim 8.1+ (require the new `terminal` feature, [reference](https://www.vim.org/vim-8.1-released.php))
+- [Neovim 0.3.8+](https://github.com/neovim/neovim)
+
 ## Configurations
 
 #### Key-bindings

--- a/plugin/CodeRunner.vim
+++ b/plugin/CodeRunner.vim
@@ -208,7 +208,11 @@ function! s:CodeRunner()
     let winName = "CodeRunner.out"
     let options= {"cwd":getcwd(),"term_rows":g:code_runner_output_window_size, "term_name":winName}
 
-    exec "belowright terminal ++shell ++rows=".g:code_runner_output_window_size." ".cmd.""
+    if has('nvim')
+        exec "belowright ".g:code_runner_output_window_size."sp ".winName." | terminal ".cmd
+    else
+        exec "belowright terminal ++shell ++rows=".g:code_runner_output_window_size." ".cmd
+    endif
 
 endfunction
 " }}}


### PR DESCRIPTION
Fix issue in neovim. #5 

Test under neiovim with below python 2 script file (test.py):
```
#!/usr/bin/env python
# -*- encofing:utf-8 -*-

print "hello python"
num = input("Please input an integer:")
print "The number is: ", num
```

- Support output to the terminal
- Support standard input from terminal (go to insert mode by: `i` or `a` command)
