### PR TITLE
Add per-project .coderunner config with priority-based loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,24 @@ let g:code_runner_command_map = {
       \ 'python' : 'python $fileName'
       \}
 ```
+
 #### Save before execution
+
 By default, the file is auto-saved before execution. To disable:
 
 ```vim
 let g:code_runner_save_before_execute = 0
+
+#### Per-project config
+Place a `.coderunner` file in your project directory or project root to override commands:
+
 ```
+python :: python3 $fileName
+node :: node --experimental-modules $fileName
+```
+
+Config priority: `.coderunner` in current dir > `.coderunner` in project root > `g:code_runner_command_config_file` > default config.
+
 
 #### Reuse output window
 By default, if the output window already exists, it will be reused instead of

--- a/doc/CodeRunner.txt
+++ b/doc/CodeRunner.txt
@@ -103,6 +103,17 @@ By default, this plugin will load a default config file which has limitted
 command associations(e.g. c++, java, python). Users can specify their own
 config file. If it is specified, the default config will not be loaded.
 
+Configuration is loaded in this priority:
+1. .coderunner in current file's directory
+2. .coderunner in project root (git repo detected)
+3. g:code_runner_command_config_file (explicit path)
+4. CodeRunnerCommandAssociations in plugin directory
+5. Default config from runtimepath
+
+To use per-project config, create a .coderunner file in your project
+directory with the same format as CodeRunnerCommandAssociations:
+  python :: python3 $fileName
+
 *g:code_runner_command_map*
 
 Command mapping configured in this map will override the settings from config file.

--- a/plugin/CodeRunner.vim
+++ b/plugin/CodeRunner.vim
@@ -95,15 +95,30 @@ endfunction
 
 " GetCommandConfigFile {{{
 function! s:GetCommandConfigFile()
-    let sawError = 0
+    " Check for .coderunner in current file's directory
+    let currentDir = expand('%:p:h')
+    let currentConfig = currentDir . '/.coderunner'
+    if filereadable(currentConfig)
+        return currentConfig
+    endif
+
+    " Check for .coderunner in project root (git repo)
+    let projectRoot = finddir('.git', currentDir . ';')
+    if !empty(projectRoot)
+        let projectRoot = fnamemodify(projectRoot, ':h')
+        let projectConfig = projectRoot . '/.coderunner'
+        if filereadable(projectConfig)
+            return projectConfig
+        endif
+    endif
+
+    " Fall back to global config
     if exists("g:code_runner_command_config_file")
         if filereadable(g:code_runner_command_config_file)
             return g:code_runner_command_config_file
         endif
-        let sawError = 1
         call CodeRunner#Error("The file specified by g:code_runner_command_config_file = " .
                     \ g:code_runner_command_config_file . " cannot be read.")
-        call CodeRunner#Error("Attempting to look for 'CodeRunnerCommandAssociations' in other locations.")
     endif
 
     let nextToSource = fnamemodify(s:CodeRunnerSourceFile, ":h")."/CodeRunnerCommandAssociations"


### PR DESCRIPTION
This PR is to solve the issue: https://github.com/xianzhon/vim-code-runner/issues/8 (Created with OpenCode)

* Search current file dir and project root for .coderunner before fallback
* Document config priority in README and help docs
* Clean up error handling in GetCommandConfigFile